### PR TITLE
chore(deps): replace colorjs.io with @colordx/core, bump color-sorter to 8.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
 		"knip": "knip"
 	},
 	"dependencies": {
+		"@colordx/core": "^5.5.0",
 		"@projectwallace/css-analyzer": "^9.9.3",
 		"@projectwallace/css-parser": "^0.18.2",
 		"@projectwallace/css-time-sort": "^3.1.0",
-		"color-sorter": "^8.0.1",
-		"colorjs.io": "^0.7.1"
+		"color-sorter": "^8.0.2"
 	},
 	"devDependencies": {
 		"@projectwallace/preset-oxlint": "^0.0.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@colordx/core':
+        specifier: ^5.5.0
+        version: 5.5.0
       '@projectwallace/css-analyzer':
         specifier: ^9.9.3
         version: 9.9.3
@@ -18,11 +21,8 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0
       color-sorter:
-        specifier: ^8.0.1
-        version: 8.0.1
-      colorjs.io:
-        specifier: ^0.7.1
-        version: 0.7.1
+        specifier: ^8.0.2
+        version: 8.0.2
     devDependencies:
       '@projectwallace/preset-oxlint':
         specifier: ^0.0.11
@@ -77,6 +77,9 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@colordx/core@5.5.0':
+    resolution: {integrity: sha512-3PxTH8itZzltK0U9jTwVVnjLXvnDYuq3m+QXsHkENxWiPRh4WaoLcs1SQjqgZ55kS+QyirpH5BVwzP2gMVG6EQ==}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -1130,12 +1133,9 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
-  color-sorter@8.0.1:
-    resolution: {integrity: sha512-8qIof2gUQbHS3yum9wOWLSXEIDvGjk1S2Vm0MGmS67N5Faf+dA1bEr+dQCfAg8f4BWUafU/H+3bS2cmv1ppTkA==}
+  color-sorter@8.0.2:
+    resolution: {integrity: sha512-6PVyJu6ufP/Buv4I5NhSjKzH0mWe0wJjPOQWIM98lC+XPtNK9NWWoP0DqQxVOTjLI2gK5lceYDhjnugo3byUZA==}
     engines: {node: '>=18.0.0'}
-
-  colorjs.io@0.7.1:
-    resolution: {integrity: sha512-LY7OHnJZxHwT5UlzNa9bbhHHDbzB6yE5+3MIPwJEQKRvSCt/T4G7epsj+9j2BExUIIfXFIJGsIXUKdfrK9Q5tA==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1660,6 +1660,8 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@colordx/core@5.5.0': {}
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -2291,11 +2293,9 @@ snapshots:
 
   chai@6.2.2: {}
 
-  color-sorter@8.0.1:
+  color-sorter@8.0.2:
     dependencies:
-      colorjs.io: 0.7.1
-
-  colorjs.io@0.7.1: {}
+      '@colordx/core': 5.5.0
 
   convert-source-map@2.0.0: {}
 

--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,7 @@ let { color } = css_to_tokens(
 
 ['Color' Design Token format](https://www.designtokens.org/tr/third-editors-draft/color/#format)
 
-Only fully compliant colors are listed. Colors that can't be parsed by [colorjs.io](https://colorjs.io/) are ignored, like `rgb(var(--red) var(--green) var(--blue))` or CSS system colors like `ButtonText`.
+Only fully compliant colors are listed. Colors that can't be parsed by [colordx](https://colordx.dev) are ignored, like `rgb(var(--red) var(--green) var(--blue))` or CSS system colors like `ButtonText`.
 
 - The optional `alpha` property is _always_ present.
 - The optional `hex` fallback property is _never_ present.
@@ -514,7 +514,7 @@ let properties = color['green-5e0cf03']['$extensions']['com.projectwallace.css-p
 
 ## Acknowledgements
 
-- [ColorJS.io](https://colorjs.io/) powers all color conversions necessary for grouping and sorting and converting into Color tokens
+- [colordx](https://colordx.dev) powers all color conversions necessary for grouping and sorting and converting into Color tokens
 
 ## Related projects
 

--- a/src/colors.ts
+++ b/src/colors.ts
@@ -1,7 +1,4 @@
-import {
-	colorKeywords as color_keywords,
-	cssKeywords as css_keywords,
-} from '@projectwallace/css-analyzer'
+import { cssKeywords as css_keywords } from '@projectwallace/css-analyzer'
 import { type ColorValue, type ColorSpace } from './types.js'
 import { colordx, extend, getFormat, type ColorFormat, type Colordx } from '@colordx/core'
 import hwb from '@colordx/core/plugins/hwb'
@@ -13,30 +10,34 @@ import a98rgb from '@colordx/core/plugins/a98rgb'
 import prophoto from '@colordx/core/plugins/prophoto'
 import names from '@colordx/core/plugins/names'
 
-// Register color spaces for parsing and converting
 extend([hwb, lab, lch, p3, rec2020, a98rgb, prophoto, names])
 
 // Full precision, to avoid rounding differences from the original authored value
 const PRECISION = 15
 
-type Converted = Pick<ColorValue, 'colorSpace' | 'components' | 'alpha'>
+type Converted = Pick<ColorValue, 'components' | 'alpha'>
 
 // `color()` spaces sharing colordx's { r, g, b, alpha } shape on a 0-1 scale
-function rgb_triple(
-	colorSpace: ColorSpace,
-	value: { r: number; g: number; b: number; alpha: number },
-): Converted {
-	return { colorSpace, components: [value.r, value.g, value.b], alpha: value.alpha }
+function rgb_triple(value: { r: number; g: number; b: number; alpha: number }): Converted {
+	return { components: [value.r, value.g, value.b], alpha: value.alpha }
 }
 
 // hex/rgb()/named colors: colordx's toRgb() is 0-255 and unscaled, unlike every other `toX()`
 function to_srgb(color: Colordx): Converted {
 	let value = color.toRgb()
 	return {
-		colorSpace: 'srgb',
 		components: [value.r / 255, value.g / 255, value.b / 255],
 		alpha: value.alpha,
 	}
+}
+
+// To map the `getFormat()` return value to a DTCG ColorSpace
+const FORMAT_TO_SPACE: Partial<Record<ColorFormat, ColorSpace>> = {
+	hex: 'srgb',
+	rgb: 'srgb',
+	name: 'srgb',
+	p3: 'display-p3',
+	xyz: 'xyz-d50',
 }
 
 // colordx has no space-agnostic "raw channels" API: every space needs its own accessor
@@ -47,69 +48,70 @@ const CONVERTERS: Partial<Record<ColorFormat, (color: Colordx) => Converted>> = 
 	name: to_srgb,
 	hsl: (color) => {
 		let value = color.toHsl(PRECISION)
-		return { colorSpace: 'hsl', components: [value.h, value.s, value.l], alpha: value.alpha }
+		return { components: [value.h, value.s, value.l], alpha: value.alpha }
 	},
 	hwb: (color) => {
 		let value = color.toHwb(PRECISION)
-		return { colorSpace: 'hwb', components: [value.h, value.w, value.b], alpha: value.alpha }
+		return { components: [value.h, value.w, value.b], alpha: value.alpha }
 	},
 	lab: (color) => {
 		let value = color.toLab(PRECISION)
-		return { colorSpace: 'lab', components: [value.l, value.a, value.b], alpha: value.alpha }
+		return { components: [value.l, value.a, value.b], alpha: value.alpha }
 	},
 	lch: (color) => {
 		let value = color.toLch(PRECISION)
-		return { colorSpace: 'lch', components: [value.l, value.c, value.h], alpha: value.alpha }
+		return { components: [value.l, value.c, value.h], alpha: value.alpha }
 	},
 	oklab: (color) => {
 		let value = color.toOklab(PRECISION)
-		return { colorSpace: 'oklab', components: [value.l, value.a, value.b], alpha: value.alpha }
+		return { components: [value.l, value.a, value.b], alpha: value.alpha }
 	},
 	oklch: (color) => {
 		let value = color.toOklch(PRECISION)
-		return { colorSpace: 'oklch', components: [value.l, value.c, value.h], alpha: value.alpha }
+		return { components: [value.l, value.c, value.h], alpha: value.alpha }
 	},
-	p3: (color) => rgb_triple('display-p3', color.toP3(PRECISION)),
-	rec2020: (color) => rgb_triple('rec2020', color.toRec2020(PRECISION)),
-	'a98-rgb': (color) => rgb_triple('a98-rgb', color.toA98(PRECISION)),
-	'prophoto-rgb': (color) => rgb_triple('prophoto-rgb', color.toProphoto(PRECISION)),
+	p3: (color) => rgb_triple(color.toP3(PRECISION)),
+	rec2020: (color) => rgb_triple(color.toRec2020(PRECISION)),
+	'a98-rgb': (color) => rgb_triple(color.toA98(PRECISION)),
+	'prophoto-rgb': (color) => rgb_triple(color.toProphoto(PRECISION)),
 	xyz: (color) => {
 		let value = color.toXyz(PRECISION)
-		return { colorSpace: 'xyz-d50', components: [value.x, value.y, value.z], alpha: value.alpha }
+		return { components: [value.x, value.y, value.z], alpha: value.alpha }
 	},
 	'xyz-d65': (color) => {
 		let value = color.toXyzD65(PRECISION)
-		return { colorSpace: 'xyz-d65', components: [value.x, value.y, value.z], alpha: value.alpha }
+		return { components: [value.x, value.y, value.z], alpha: value.alpha }
 	},
 }
 
 export function color_to_token(color: string): ColorValue | null {
 	let lowercased = color.toLowerCase()
 
-	// The keyword "transparent" specifies a transparent black.
-	// > https://drafts.csswg.org/css-color-4/#transparent-color
-	if (lowercased === 'transparent') {
-		return {
-			colorSpace: 'srgb',
-			components: [0, 0, 0],
-			alpha: 0,
-		}
-	}
-
-	if (css_keywords.has(lowercased) || color_keywords.has(lowercased)) {
+	if (
+		css_keywords.has(lowercased) ||
+		lowercased === 'currentcolor' ||
+		lowercased.includes('var(')
+	) {
 		return null
 	}
 
-	if (lowercased.includes('var(')) {
+	let parsed = colordx(color)
+	if (!parsed.isValid()) {
 		return null
 	}
 
 	let format = getFormat(color)
-	let convert = format && CONVERTERS[format]
-	if (!convert) return null
 
-	let parsed = colordx(color)
-	if (!parsed.isValid()) return null
+	if (!format) {
+		return null
+	}
 
-	return convert(parsed)
+	let colorSpace = (FORMAT_TO_SPACE[format] ?? format) as ColorSpace
+	let converter_fn = format && CONVERTERS[format]
+
+	if (!converter_fn) {
+		return null
+	}
+
+	return { colorSpace, ...converter_fn(parsed) }
 }

--- a/src/colors.ts
+++ b/src/colors.ts
@@ -19,10 +19,6 @@ extend([hwb, lab, lch, p3, rec2020, a98rgb, prophoto, names])
 // Full precision, to avoid rounding differences from the original authored value
 const PRECISION = 15
 
-// colordx resolves a `none` alpha to 0 (fully transparent); fall back to 1 instead,
-// like the previous colorjs.io-based implementation did.
-const NONE_ALPHA_RE = /\/\s*none\s*\)?\s*$/i
-
 export function color_to_token(color: string): ColorValue | null {
 	let lowercased = color.toLowerCase()
 
@@ -50,8 +46,6 @@ export function color_to_token(color: string): ColorValue | null {
 	let parsed = colordx(color)
 	if (!parsed.isValid()) return null
 
-	let alpha_none = NONE_ALPHA_RE.test(color)
-
 	switch (format) {
 		case 'hex':
 		case 'rgb':
@@ -60,7 +54,7 @@ export function color_to_token(color: string): ColorValue | null {
 			return {
 				colorSpace: 'srgb',
 				components: [rgb.r / 255, rgb.g / 255, rgb.b / 255],
-				alpha: alpha_none ? 1 : rgb.alpha,
+				alpha: rgb.alpha,
 			}
 		}
 		case 'hsl': {
@@ -68,7 +62,7 @@ export function color_to_token(color: string): ColorValue | null {
 			return {
 				colorSpace: 'hsl',
 				components: [value.h, value.s, value.l],
-				alpha: alpha_none ? 1 : value.alpha,
+				alpha: value.alpha,
 			}
 		}
 		case 'hwb': {
@@ -76,7 +70,7 @@ export function color_to_token(color: string): ColorValue | null {
 			return {
 				colorSpace: 'hwb',
 				components: [value.h, value.w, value.b],
-				alpha: alpha_none ? 1 : value.alpha,
+				alpha: value.alpha,
 			}
 		}
 		case 'lab': {
@@ -84,7 +78,7 @@ export function color_to_token(color: string): ColorValue | null {
 			return {
 				colorSpace: 'lab',
 				components: [value.l, value.a, value.b],
-				alpha: alpha_none ? 1 : value.alpha,
+				alpha: value.alpha,
 			}
 		}
 		case 'lch': {
@@ -92,7 +86,7 @@ export function color_to_token(color: string): ColorValue | null {
 			return {
 				colorSpace: 'lch',
 				components: [value.l, value.c, value.h],
-				alpha: alpha_none ? 1 : value.alpha,
+				alpha: value.alpha,
 			}
 		}
 		case 'oklab': {
@@ -100,7 +94,7 @@ export function color_to_token(color: string): ColorValue | null {
 			return {
 				colorSpace: 'oklab',
 				components: [value.l, value.a, value.b],
-				alpha: alpha_none ? 1 : value.alpha,
+				alpha: value.alpha,
 			}
 		}
 		case 'oklch': {
@@ -108,7 +102,7 @@ export function color_to_token(color: string): ColorValue | null {
 			return {
 				colorSpace: 'oklch',
 				components: [value.l, value.c, value.h],
-				alpha: alpha_none ? 1 : value.alpha,
+				alpha: value.alpha,
 			}
 		}
 		case 'p3': {
@@ -116,7 +110,7 @@ export function color_to_token(color: string): ColorValue | null {
 			return {
 				colorSpace: 'display-p3',
 				components: [value.r, value.g, value.b],
-				alpha: alpha_none ? 1 : value.alpha,
+				alpha: value.alpha,
 			}
 		}
 		case 'rec2020': {
@@ -124,7 +118,7 @@ export function color_to_token(color: string): ColorValue | null {
 			return {
 				colorSpace: 'rec2020',
 				components: [value.r, value.g, value.b],
-				alpha: alpha_none ? 1 : value.alpha,
+				alpha: value.alpha,
 			}
 		}
 		case 'a98-rgb': {
@@ -132,7 +126,7 @@ export function color_to_token(color: string): ColorValue | null {
 			return {
 				colorSpace: 'a98-rgb',
 				components: [value.r, value.g, value.b],
-				alpha: alpha_none ? 1 : value.alpha,
+				alpha: value.alpha,
 			}
 		}
 		case 'prophoto-rgb': {
@@ -140,7 +134,7 @@ export function color_to_token(color: string): ColorValue | null {
 			return {
 				colorSpace: 'prophoto-rgb',
 				components: [value.r, value.g, value.b],
-				alpha: alpha_none ? 1 : value.alpha,
+				alpha: value.alpha,
 			}
 		}
 		case 'xyz': {
@@ -148,7 +142,7 @@ export function color_to_token(color: string): ColorValue | null {
 			return {
 				colorSpace: 'xyz-d50',
 				components: [value.x, value.y, value.z],
-				alpha: alpha_none ? 1 : value.alpha,
+				alpha: value.alpha,
 			}
 		}
 		case 'xyz-d65': {
@@ -156,7 +150,7 @@ export function color_to_token(color: string): ColorValue | null {
 			return {
 				colorSpace: 'xyz-d65',
 				components: [value.x, value.y, value.z],
-				alpha: alpha_none ? 1 : value.alpha,
+				alpha: value.alpha,
 			}
 		}
 		default:

--- a/src/colors.ts
+++ b/src/colors.ts
@@ -2,59 +2,26 @@ import {
 	colorKeywords as color_keywords,
 	cssKeywords as css_keywords,
 } from '@projectwallace/css-analyzer'
-import { type ColorValue, type ColorSpace as tColorSpace } from './types.js'
-import {
-	tryColor,
-	ColorSpace,
-	XYZ_D65,
-	XYZ_D50,
-	XYZ_ABS_D65,
-	Lab_D65,
-	Lab,
-	LCH,
-	sRGB_Linear,
-	sRGB,
-	HSL,
-	HWB,
-	HSV,
-	P3_Linear,
-	P3,
-	A98RGB_Linear,
-	A98RGB,
-	ProPhoto_Linear,
-	ProPhoto,
-	REC_2020_Linear,
-	REC_2020,
-	OKLab,
-	OKLCH,
-	OKLrab,
-} from 'colorjs.io/fn'
+import { type ColorValue } from './types.js'
+import { colordx, extend, getFormat, type ColorFormat } from '@colordx/core'
+import hwb from '@colordx/core/plugins/hwb'
+import lab from '@colordx/core/plugins/lab'
+import lch from '@colordx/core/plugins/lch'
+import p3 from '@colordx/core/plugins/p3'
+import rec2020 from '@colordx/core/plugins/rec2020'
+import a98rgb from '@colordx/core/plugins/a98rgb'
+import prophoto from '@colordx/core/plugins/prophoto'
+import names from '@colordx/core/plugins/names'
 
 // Register color spaces for parsing and converting
-// TODO: According to the changelog we should be able to import
-// and register all spaces in one go but it doesn't seem to work
-ColorSpace.register(sRGB) // Parses keywords and hex colors
-ColorSpace.register(XYZ_D65)
-ColorSpace.register(XYZ_D50)
-ColorSpace.register(XYZ_ABS_D65)
-ColorSpace.register(Lab_D65)
-ColorSpace.register(Lab)
-ColorSpace.register(LCH)
-ColorSpace.register(sRGB_Linear)
-ColorSpace.register(HSL)
-ColorSpace.register(HWB)
-ColorSpace.register(HSV)
-ColorSpace.register(P3_Linear)
-ColorSpace.register(P3)
-ColorSpace.register(A98RGB_Linear)
-ColorSpace.register(A98RGB)
-ColorSpace.register(ProPhoto_Linear)
-ColorSpace.register(ProPhoto)
-ColorSpace.register(REC_2020_Linear)
-ColorSpace.register(REC_2020)
-ColorSpace.register(OKLab)
-ColorSpace.register(OKLCH)
-ColorSpace.register(OKLrab)
+extend([hwb, lab, lch, p3, rec2020, a98rgb, prophoto, names])
+
+// Full precision, to avoid rounding differences from the original authored value
+const PRECISION = 15
+
+// colordx resolves a `none` alpha to 0 (fully transparent); fall back to 1 instead,
+// like the previous colorjs.io-based implementation did.
+const NONE_ALPHA_RE = /\/\s*none\s*\)?\s*$/i
 
 export function color_to_token(color: string): ColorValue | null {
 	let lowercased = color.toLowerCase()
@@ -77,14 +44,122 @@ export function color_to_token(color: string): ColorValue | null {
 		return null
 	}
 
-	let parsed_color = tryColor(color)
+	let format: ColorFormat | undefined = getFormat(color)
+	if (format === undefined) return null
 
-	if (parsed_color === null) return null
-	let [component_a, component_b, component_c] = parsed_color.coords
+	let parsed = colordx(color)
+	if (!parsed.isValid()) return null
 
-	return {
-		colorSpace: parsed_color.space.id as tColorSpace,
-		components: [component_a ?? 'none', component_b ?? 'none', component_c ?? 'none'],
-		alpha: parsed_color.alpha ?? 1,
+	let alpha_none = NONE_ALPHA_RE.test(color)
+
+	switch (format) {
+		case 'hex':
+		case 'rgb':
+		case 'name': {
+			let rgb = parsed.toRgb()
+			return {
+				colorSpace: 'srgb',
+				components: [rgb.r / 255, rgb.g / 255, rgb.b / 255],
+				alpha: alpha_none ? 1 : rgb.alpha,
+			}
+		}
+		case 'hsl': {
+			let value = parsed.toHsl(PRECISION)
+			return {
+				colorSpace: 'hsl',
+				components: [value.h, value.s, value.l],
+				alpha: alpha_none ? 1 : value.alpha,
+			}
+		}
+		case 'hwb': {
+			let value = parsed.toHwb(PRECISION)
+			return {
+				colorSpace: 'hwb',
+				components: [value.h, value.w, value.b],
+				alpha: alpha_none ? 1 : value.alpha,
+			}
+		}
+		case 'lab': {
+			let value = parsed.toLab(PRECISION)
+			return {
+				colorSpace: 'lab',
+				components: [value.l, value.a, value.b],
+				alpha: alpha_none ? 1 : value.alpha,
+			}
+		}
+		case 'lch': {
+			let value = parsed.toLch(PRECISION)
+			return {
+				colorSpace: 'lch',
+				components: [value.l, value.c, value.h],
+				alpha: alpha_none ? 1 : value.alpha,
+			}
+		}
+		case 'oklab': {
+			let value = parsed.toOklab(PRECISION)
+			return {
+				colorSpace: 'oklab',
+				components: [value.l, value.a, value.b],
+				alpha: alpha_none ? 1 : value.alpha,
+			}
+		}
+		case 'oklch': {
+			let value = parsed.toOklch(PRECISION)
+			return {
+				colorSpace: 'oklch',
+				components: [value.l, value.c, value.h],
+				alpha: alpha_none ? 1 : value.alpha,
+			}
+		}
+		case 'p3': {
+			let value = parsed.toP3(PRECISION)
+			return {
+				colorSpace: 'display-p3',
+				components: [value.r, value.g, value.b],
+				alpha: alpha_none ? 1 : value.alpha,
+			}
+		}
+		case 'rec2020': {
+			let value = parsed.toRec2020(PRECISION)
+			return {
+				colorSpace: 'rec2020',
+				components: [value.r, value.g, value.b],
+				alpha: alpha_none ? 1 : value.alpha,
+			}
+		}
+		case 'a98-rgb': {
+			let value = parsed.toA98(PRECISION)
+			return {
+				colorSpace: 'a98-rgb',
+				components: [value.r, value.g, value.b],
+				alpha: alpha_none ? 1 : value.alpha,
+			}
+		}
+		case 'prophoto-rgb': {
+			let value = parsed.toProphoto(PRECISION)
+			return {
+				colorSpace: 'prophoto-rgb',
+				components: [value.r, value.g, value.b],
+				alpha: alpha_none ? 1 : value.alpha,
+			}
+		}
+		case 'xyz': {
+			let value = parsed.toXyz(PRECISION)
+			return {
+				colorSpace: 'xyz-d50',
+				components: [value.x, value.y, value.z],
+				alpha: alpha_none ? 1 : value.alpha,
+			}
+		}
+		case 'xyz-d65': {
+			let value = parsed.toXyzD65(PRECISION)
+			return {
+				colorSpace: 'xyz-d65',
+				components: [value.x, value.y, value.z],
+				alpha: alpha_none ? 1 : value.alpha,
+			}
+		}
+		default:
+			return null
 	}
 }

--- a/src/colors.ts
+++ b/src/colors.ts
@@ -2,8 +2,8 @@ import {
 	colorKeywords as color_keywords,
 	cssKeywords as css_keywords,
 } from '@projectwallace/css-analyzer'
-import { type ColorValue } from './types.js'
-import { colordx, extend, getFormat, type ColorFormat } from '@colordx/core'
+import { type ColorValue, type ColorSpace } from './types.js'
+import { colordx, extend, getFormat, type ColorFormat, type Colordx } from '@colordx/core'
 import hwb from '@colordx/core/plugins/hwb'
 import lab from '@colordx/core/plugins/lab'
 import lch from '@colordx/core/plugins/lch'
@@ -18,6 +18,70 @@ extend([hwb, lab, lch, p3, rec2020, a98rgb, prophoto, names])
 
 // Full precision, to avoid rounding differences from the original authored value
 const PRECISION = 15
+
+type Converted = Pick<ColorValue, 'colorSpace' | 'components' | 'alpha'>
+
+// `color()` spaces sharing colordx's { r, g, b, alpha } shape on a 0-1 scale
+function rgb_triple(
+	colorSpace: ColorSpace,
+	value: { r: number; g: number; b: number; alpha: number },
+): Converted {
+	return { colorSpace, components: [value.r, value.g, value.b], alpha: value.alpha }
+}
+
+// hex/rgb()/named colors: colordx's toRgb() is 0-255 and unscaled, unlike every other `toX()`
+function to_srgb(color: Colordx): Converted {
+	let value = color.toRgb()
+	return {
+		colorSpace: 'srgb',
+		components: [value.r / 255, value.g / 255, value.b / 255],
+		alpha: value.alpha,
+	}
+}
+
+// colordx has no space-agnostic "raw channels" API: every space needs its own accessor
+// since the returned properties differ (r/g/b, h/s/l, l/a/b, l/c/h, x/y/z, ...)
+const CONVERTERS: Partial<Record<ColorFormat, (color: Colordx) => Converted>> = {
+	hex: to_srgb,
+	rgb: to_srgb,
+	name: to_srgb,
+	hsl: (color) => {
+		let value = color.toHsl(PRECISION)
+		return { colorSpace: 'hsl', components: [value.h, value.s, value.l], alpha: value.alpha }
+	},
+	hwb: (color) => {
+		let value = color.toHwb(PRECISION)
+		return { colorSpace: 'hwb', components: [value.h, value.w, value.b], alpha: value.alpha }
+	},
+	lab: (color) => {
+		let value = color.toLab(PRECISION)
+		return { colorSpace: 'lab', components: [value.l, value.a, value.b], alpha: value.alpha }
+	},
+	lch: (color) => {
+		let value = color.toLch(PRECISION)
+		return { colorSpace: 'lch', components: [value.l, value.c, value.h], alpha: value.alpha }
+	},
+	oklab: (color) => {
+		let value = color.toOklab(PRECISION)
+		return { colorSpace: 'oklab', components: [value.l, value.a, value.b], alpha: value.alpha }
+	},
+	oklch: (color) => {
+		let value = color.toOklch(PRECISION)
+		return { colorSpace: 'oklch', components: [value.l, value.c, value.h], alpha: value.alpha }
+	},
+	p3: (color) => rgb_triple('display-p3', color.toP3(PRECISION)),
+	rec2020: (color) => rgb_triple('rec2020', color.toRec2020(PRECISION)),
+	'a98-rgb': (color) => rgb_triple('a98-rgb', color.toA98(PRECISION)),
+	'prophoto-rgb': (color) => rgb_triple('prophoto-rgb', color.toProphoto(PRECISION)),
+	xyz: (color) => {
+		let value = color.toXyz(PRECISION)
+		return { colorSpace: 'xyz-d50', components: [value.x, value.y, value.z], alpha: value.alpha }
+	},
+	'xyz-d65': (color) => {
+		let value = color.toXyzD65(PRECISION)
+		return { colorSpace: 'xyz-d65', components: [value.x, value.y, value.z], alpha: value.alpha }
+	},
+}
 
 export function color_to_token(color: string): ColorValue | null {
 	let lowercased = color.toLowerCase()
@@ -40,120 +104,12 @@ export function color_to_token(color: string): ColorValue | null {
 		return null
 	}
 
-	let format: ColorFormat | undefined = getFormat(color)
-	if (format === undefined) return null
+	let format = getFormat(color)
+	let convert = format && CONVERTERS[format]
+	if (!convert) return null
 
 	let parsed = colordx(color)
 	if (!parsed.isValid()) return null
 
-	switch (format) {
-		case 'hex':
-		case 'rgb':
-		case 'name': {
-			let rgb = parsed.toRgb()
-			return {
-				colorSpace: 'srgb',
-				components: [rgb.r / 255, rgb.g / 255, rgb.b / 255],
-				alpha: rgb.alpha,
-			}
-		}
-		case 'hsl': {
-			let value = parsed.toHsl(PRECISION)
-			return {
-				colorSpace: 'hsl',
-				components: [value.h, value.s, value.l],
-				alpha: value.alpha,
-			}
-		}
-		case 'hwb': {
-			let value = parsed.toHwb(PRECISION)
-			return {
-				colorSpace: 'hwb',
-				components: [value.h, value.w, value.b],
-				alpha: value.alpha,
-			}
-		}
-		case 'lab': {
-			let value = parsed.toLab(PRECISION)
-			return {
-				colorSpace: 'lab',
-				components: [value.l, value.a, value.b],
-				alpha: value.alpha,
-			}
-		}
-		case 'lch': {
-			let value = parsed.toLch(PRECISION)
-			return {
-				colorSpace: 'lch',
-				components: [value.l, value.c, value.h],
-				alpha: value.alpha,
-			}
-		}
-		case 'oklab': {
-			let value = parsed.toOklab(PRECISION)
-			return {
-				colorSpace: 'oklab',
-				components: [value.l, value.a, value.b],
-				alpha: value.alpha,
-			}
-		}
-		case 'oklch': {
-			let value = parsed.toOklch(PRECISION)
-			return {
-				colorSpace: 'oklch',
-				components: [value.l, value.c, value.h],
-				alpha: value.alpha,
-			}
-		}
-		case 'p3': {
-			let value = parsed.toP3(PRECISION)
-			return {
-				colorSpace: 'display-p3',
-				components: [value.r, value.g, value.b],
-				alpha: value.alpha,
-			}
-		}
-		case 'rec2020': {
-			let value = parsed.toRec2020(PRECISION)
-			return {
-				colorSpace: 'rec2020',
-				components: [value.r, value.g, value.b],
-				alpha: value.alpha,
-			}
-		}
-		case 'a98-rgb': {
-			let value = parsed.toA98(PRECISION)
-			return {
-				colorSpace: 'a98-rgb',
-				components: [value.r, value.g, value.b],
-				alpha: value.alpha,
-			}
-		}
-		case 'prophoto-rgb': {
-			let value = parsed.toProphoto(PRECISION)
-			return {
-				colorSpace: 'prophoto-rgb',
-				components: [value.r, value.g, value.b],
-				alpha: value.alpha,
-			}
-		}
-		case 'xyz': {
-			let value = parsed.toXyz(PRECISION)
-			return {
-				colorSpace: 'xyz-d50',
-				components: [value.x, value.y, value.z],
-				alpha: value.alpha,
-			}
-		}
-		case 'xyz-d65': {
-			let value = parsed.toXyzD65(PRECISION)
-			return {
-				colorSpace: 'xyz-d65',
-				components: [value.x, value.y, value.z],
-				alpha: value.alpha,
-			}
-		}
-		default:
-			return null
-	}
+	return convert(parsed)
 }


### PR DESCRIPTION
Closes #104

## Summary

- Replaces `colorjs.io` with `@colordx/core` in `src/colors.ts`. colordx has no space-agnostic "raw channels" API (unlike colorjs.io's registered-space parser), so parsing is driven by a `CONVERTERS` lookup table keyed on colordx's `getFormat()` result, each entry calling the matching `toX()` conversion (`toHsl`, `toOklch`, `toLab`, `toP3`, …) at full precision. `p3`/`rec2020`/`a98-rgb`/`prophoto-rgb` share one helper (identical `{r,g,b,alpha}` shape on colordx's side), as do `hex`/`rgb()`/named colors.
- Bumps `color-sorter` to `^8.0.2`, which made this same colorjs.io → colordx swap internally (its public `convert()` API is unchanged, so `src/group-colors.ts` needed no changes).
- Updates the two colorjs.io mentions in `readme.md` to point at colordx.

## Behavioral notes

- `color(srgb ...)` / `color(srgb-linear ...)` are no longer parseable — colordx doesn't implement those two predefined-space functions (unlike colorjs.io). They're now treated the same as any other unparseable color and silently dropped, consistent with the documented "colors that can't be parsed are ignored" policy.
- The CSS Color 4 `none` keyword no longer round-trips as the literal `"none"` token in a color component (colordx has no way to preserve that marker — it resolves `none` to `0` internally, which is spec-correct: a missing component behaves as zero for every purpose except interpolation). No special-casing needed here — colordx's native behavior is used as-is, including for alpha (`rgb(0 128 0 / none)` correctly yields `alpha: 0`, matching browser rendering).
- Values may differ from colorjs.io in far-decimal-place precision (e.g. `oklch(0.5 0.2 240)` round-trips to `l: 0.499999996736773` instead of the literal `0.5`), because colordx always converts through its internal representation rather than echoing authored coordinates untouched.

## Install size

| Package | Before | After | Change |
|---|---:|---:|---:|
| Color library | `colorjs.io@0.7.1` — 15.78 MB | `@colordx/core@5.5.0` — 0.91 MB | **−94.2%** |
| `color-sorter` | `8.0.1` — 10.0 kB | `8.0.2` — 9.6 kB | −4% |
| **Total** | **15.79 MB** | **0.92 MB** | **−94.2%** |

*(unpacked sizes per npm registry metadata; color-sorter's own colorjs.io/colordx dependency is included in the totals above since both packages shared the same color library)*

## Bundle size

`dist/index.js` output from `tsdown` (tree-shaken):

| | Before | After | Change |
|---|---:|---:|---:|
| Raw | 18.86 kB | 20.54 kB | +1.68 kB (+8.9%) |
| Gzip | 4.60 kB | 4.87 kB | +0.27 kB (+5.9%) |

The bundled output grew slightly rather than shrinking — colordx's core is small, but preserving full color-space parity with the old colorjs.io setup requires loading 8 of its plugins (`hwb`, `lab`, `lch`, `p3`, `rec2020`, `a98rgb`, `prophoto`, `names`), which adds more tree-shaken code than colorjs.io/fn's narrower imports did. The install-size win is the real payoff of this migration; bundle size is a minor regression.

## Test plan

- [x] `pnpm run check` (tsc --noEmit)
- [x] `pnpm run lint` (oxlint + oxfmt)
- [x] `pnpm run test` — all 100 existing tests pass unchanged
- [x] `pnpm run knip`
- [x] `pnpm run build` (tsdown + publint)
- [x] Manually verified parsing/conversion output for hex, named, rgb, hsl, hwb, lab, lch, oklab, oklch, display-p3, rec2020, a98-rgb, prophoto-rgb, xyz-d50, xyz-d65, `transparent`, `none` components/alpha, `var()`, system colors, and unparseable input against expected behavior